### PR TITLE
Kubernetes networks

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-homework
+  namespace: homework
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      volumes:
+        - name: shared-volume
+          emptyDir: {}
+
+      initContainers:
+        - name: init-container
+          image: busybox:stable
+          command: ['sh', '-c', 'ls /init/ > /init/index.html']
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /init
+      nodeSelector:
+        kubernetes.io/hostname: worker3
+      containers:
+        - name: main-container
+          image: python:3.9-slim
+          command: ["python3", "-m", "http.server", "8000", "--directory", "/"]
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - 'test -f /homework/index.html'
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "rm -f /homework/index.html"]

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -19,3 +19,10 @@ spec:
             name: my-service
             port:
               number: 8000
+      - pathType: Prefix
+        path: "/homepage"
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 8000

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  namespace: homework
+
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /homework/index.html
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 8000

--- a/namespace.yaml
+++ b/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: homework
+spec:
+  type: ClusterIP
+  selector:
+    app: app 
+  ports:
+  - port: 8000 
+    targetPort: 8000 


### PR DESCRIPTION
# Выполнено ДЗ №3
● Изменить readiness-пробу в манифесте deployment.yaml из
прошлого ДЗ на httpGet, вызывающую URL /index.html
● Необходимо создать манифест service.yaml, описывающий сервис
типа ClusterIP, который будет направлять трафик на поды,
управляемые вашим deployment
● Установить в кластер ingress-контроллер nginx
● Создать манифест ingress.yaml, в котором будет описан объект
типа ingress, направляющий все http запросы к хосту
homework.otus на ранее созданный сервис. В результате запрос
http://homework.otus/index.html должен отдавать код html
страницы, находящейся в подах
Задание с *
● Доработать манифест ingress.yaml, описав в нем rewrite-правила
так, чтобы обращение по адресу http://homework.otus/homepage
форвардилось на http://homework.otus/index.html

## В процессе сделано:
 - Пункт 1
 - Пункт 2

## Как запустить проект:
kubectl apply -f ingress.yaml
kubectl apply -f service.yaml
kubectl apply -f deploy.yaml
kubectl apply -f namespace.yaml
echo "192.168.1.132     homework.otus" >> /etc/hosts 
192.168.1.132 was provided by metallb
## Как проверить работоспособность:
curl homework.otus
curl homework.otus/homepage
## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
