### PR TITLE
Kubernetes volumes

### DIFF
--- a/cm.yaml
+++ b/cm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+  namespace: homework
+data:
+  index.html: |
+    123

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-homework
+  name: nginx-deployment
   namespace: homework
 spec:
   replicas: 3
@@ -10,44 +10,56 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0
-  template:
+ 
   selector:
     matchLabels:
-      app: app
+      app: nginx
   template:
     metadata:
       labels:
-        app: app
+        app: nginx
+
     spec:
       volumes:
-        - name: shared-volume
-          emptyDir: {}
-
+      - name: nginx-config-volume
+        configMap:
+          name: nginx-config
+          items:
+          - key: default.conf
+            path: default.conf
+      - name: shared-volume
+        emptyDir: {}
+      - name: my-configmap
+        configMap:
+          name: my-configmap
+      
       initContainers:
-        - name: init-container
-          image: busybox:stable
-          command: ['sh', '-c', 'ls /init/ > /init/index.html']
-          volumeMounts:
-            - name: shared-volume
-              mountPath: /init
+      - name: init-container
+        image: busybox:stable
+        command: ['sh', '-c', echo 'Hello!'   > /init/index.html]
+        volumeMounts:
+        - name: shared-volume
+          mountPath: /init
       nodeSelector:
         kubernetes.io/hostname: worker3
       containers:
-        - name: main-container
-          image: python:3.9-slim
-          command: ["python3", "-m", "http.server", "8000", "--directory", "/"]
-          ports:
-            - containerPort: 8000
-          volumeMounts:
-            - name: shared-volume
-              mountPath: /homework
-          readinessProbe:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: nginx-config-volume
+          mountPath: /etc/nginx/conf.d/
+          readOnly: true
+        - name: shared-volume
+          mountPath: /homework
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - 'test -f /homework/index.html'
+        lifecycle:
+          preStop:
             exec:
-              command:
-              - sh
-              - -c
-              - 'test -f /homework/index.html'
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "rm -f /homework/index.html"]
+              command: ["sh", "-c", "rm -f /homework/index.html"]

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-homework
+  namespace: homework
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      volumes:
+        - name: shared-volume
+          emptyDir: {}
+
+      initContainers:
+        - name: init-container
+          image: busybox:stable
+          command: ['sh', '-c', 'ls /init/ > /init/index.html']
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /init
+      nodeSelector:
+        kubernetes.io/hostname: worker3
+      containers:
+        - name: main-container
+          image: python:3.9-slim
+          command: ["python3", "-m", "http.server", "8000", "--directory", "/"]
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+          readinessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - 'test -f /homework/index.html'
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "rm -f /homework/index.html"]

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -27,8 +27,9 @@ spec:
           items:
           - key: default.conf
             path: default.conf
-      - name: shared-volume
-        emptyDir: {}
+      - name: my-pvc
+        persistentVolumeClaim:
+          claimName: my-pvc
       - name: my-configmap
         configMap:
           name: my-configmap
@@ -38,7 +39,7 @@ spec:
         image: busybox:stable
         command: ['sh', '-c', echo 'Hello!'   > /init/index.html]
         volumeMounts:
-        - name: shared-volume
+        - name: my-pvc
           mountPath: /init
       nodeSelector:
         kubernetes.io/hostname: worker3
@@ -51,8 +52,10 @@ spec:
         - name: nginx-config-volume
           mountPath: /etc/nginx/conf.d/
           readOnly: true
-        - name: shared-volume
+        - name: my-pvc
           mountPath: /homework
+        - name: my-configmap
+          mountPath: /homework/conf/file
         readinessProbe:
           exec:
             command:

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -19,3 +19,10 @@ spec:
             name: my-service
             port:
               number: 8000
+      - pathType: Prefix
+        path: "/homepage"
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 8000

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  namespace: homework
+
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /homework/index.html
+spec:
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: my-service
+            port:
+              number: 8000

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -6,21 +6,21 @@ metadata:
 
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /homework/index.html
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
   - host: homework.otus
     http:
       paths:
-      - pathType: Prefix
-        path: "/"
+      - path: /homepage(/|$)(.*)
+        pathType: ImplementationSpecific
         backend:
           service:
             name: my-service
             port:
               number: 8000
-      - pathType: Prefix
-        path: "/homepage"
+      - path: /index.html
+        pathType: ImplementationSpecific
         backend:
           service:
             name: my-service

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -6,20 +6,14 @@ metadata:
 
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
   - host: homework.otus
     http:
       paths:
-      - path: /homepage(/|$)(.*)
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: my-service
-            port:
-              number: 8000
-      - path: /index.html
+      - path: /homepage(/.*|$)|/(.*)
         pathType: ImplementationSpecific
         backend:
           service:

--- a/namespace.yaml
+++ b/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/nginx_cm.yaml
+++ b/nginx_cm.yaml
@@ -10,7 +10,8 @@ data:
         server_name localhost;
 
         location / {
-            root //homework;
+            root /homework;
             index index.html index.htm;
+            autoindex on;
         }
     }

--- a/nginx_cm.yaml
+++ b/nginx_cm.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 8000;
+        server_name localhost;
+
+        location / {
+            root //homework;
+            index index.html index.htm;
+        }
+    }

--- a/pv.yaml
+++ b/pv.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: my-pv
+  namespace: homework
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 15Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: 192.168.1.118
+    path: /mnt/nfsdir

--- a/pvc.yaml
+++ b/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: my-pvc
+  namespace: homework
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: "my-storageclass"

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: homework
+spec:
+  type: ClusterIP
+  selector:
+    app: app 
+  ports:
+  - port: 8000 
+    targetPort: 8000 

--- a/service.yaml
+++ b/service.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: app 
+    app: nginx 
   ports:
-  - port: 8000 
-    targetPort: 8000 
+  - port: 8000
+    targetPort: 8000

--- a/storageclass.yaml
+++ b/storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: my-storageclass
+  namespace: homework
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
● Создать манифест pvc.yaml, описывающий
PersistentVolumeClaim, запрашивающий хранилище с
storageClass по-умолчанию
● Создать манифест cm.yaml для объекта типа configMap,
описывающий произвольный набор пар ключ-значение
● В манифесте deployment.yaml изменить спецификацию
volume типа emptyDir, который монтируется в init и
основной контейнер, на pvc, созданный в предыдущем
пункте
● В манифесте deployment.yaml добавить монтирование
ранее созданного configMap как volume к основному
контейнеру пода в директорию /homework/conf, так, чтобы
его содержимое можно было получить, обратившись по url
/conf/file
Задание с *
● Создать манифест storageClass.yaml описывающий объект
типа storageClass с provisioner
https://k8s.io/minikube-hostpath и reclaimPolicy Retain
● Изменить манифест pvc.yaml так, чтобы в нем
запрашивалось хранилище созданного вами storageClass-а

## Как запустить проект:
kubectl apply -f   *

## Как проверить работоспособность:
Перейти по ссылке http://homework.otus/conf/file/

